### PR TITLE
Downgrade the "same `lib` name" error to warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +166,7 @@ dependencies = [
 name = "cargo-udeps"
 version = "0.1.4"
 dependencies = [
+ "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1208,6 +1217,7 @@ dependencies = [
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 cargo = "0.38"
 which = "3.0"
+ansi_term = "0.12"
 
 [profile.dev]
 debug = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,12 @@ extern crate which;
 
 mod defs;
 
-use std::fmt::Display;
+use std::fmt::{Display, Write as _};
 use std::sync::Arc;
 use std::path::{Path, PathBuf};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Mutex;
+use std::ops::Deref as _;
 use defs::CrateSaveAnalysis;
 use cargo::core::shell::Shell;
 use cargo::core::compiler::{Executor, DefaultExecutor, Unit};
@@ -20,7 +21,7 @@ use cargo::util::errors::CargoResult;
 use cargo::core::shell::Verbosity;
 use cargo::util::command_prelude::{App, Arg, opt, ArgMatchesExt,
 	AppExt, CompileMode, Config};
-use cargo::core::InternedString;
+use cargo::core::{InternedString, Package, Resolve};
 use cargo::ops::Packages;
 
 fn cli() -> App {
@@ -272,9 +273,112 @@ fn cmd_info(id :PackageId, custom_build :bool, cmd :&ProcessBuilder) -> Result<C
 #[derive(Debug, Default)]
 struct DependencyNames {
 	normal_dev_by_extern_crate_name :HashMap<String, InternedString>,
-	normal_dev_by_lib_true_snakecased_name :HashMap<String, InternedString>,
+	normal_dev_by_lib_true_snakecased_name :HashMap<String, HashSet<InternedString>>,
 	build_by_extern_crate_name :HashMap<String, InternedString>,
-	build_by_lib_true_snakecased_name :HashMap<String, InternedString>,
+	build_by_lib_true_snakecased_name :HashMap<String, HashSet<InternedString>>,
+}
+
+impl DependencyNames {
+	fn new(
+		from :&Package,
+		packages :&HashMap<PackageId, &Package>,
+		resolve :&Resolve,
+		shell :&mut Shell,
+	) -> CargoResult<Self> {
+		fn ambiguous_names(
+			names :&HashMap<String, HashSet<InternedString>>,
+		) -> BTreeMap<InternedString, &str> {
+			names
+				.iter()
+				.filter(|(_, v)| v.len() > 1)
+				.flat_map(|(k, v)| v.iter().map(move |&v| (v, k.deref())))
+				.collect()
+		}
+
+		let mut this = Self::default();
+
+		if let Some(lib) = from.targets().iter().find(|t| t.is_lib()) {
+			let name = resolve.extern_crate_name(from.package_id(), from.package_id(), lib)?;
+			this.normal_dev_by_extern_crate_name.insert(name.clone(), from.name());
+			this.normal_dev_by_lib_true_snakecased_name
+				.entry(name.clone())
+				.or_insert_with(HashSet::new)
+				.insert(from.name());
+		}
+
+		let from = from.package_id();
+
+		for (to_pkg, deps) in resolve.deps(from) {
+			let to_lib = packages
+				.get(&to_pkg)
+				.unwrap_or_else(|| panic!("could not find `{}`", &to_pkg))
+				.targets()
+				.iter()
+				.find(|t| t.is_lib())
+				.unwrap_or_else(|| panic!("`{}` does not have any `lib` target", to_pkg));
+
+			let extern_crate_name = resolve.extern_crate_name(from, to_pkg, to_lib)?;
+			let lib_true_snakecased_name = to_lib.name().replace('-', "_");
+
+			for dep in deps {
+				let (by_extern_crate_name, by_lib_true_snakecased_name) = if dep.is_build() {
+					(
+						&mut this.build_by_extern_crate_name,
+						&mut this.build_by_lib_true_snakecased_name,
+					)
+				} else {
+					(
+						&mut this.normal_dev_by_extern_crate_name,
+						&mut this.normal_dev_by_lib_true_snakecased_name,
+					)
+				};
+
+				by_extern_crate_name.insert(extern_crate_name.clone(), dep.name_in_toml());
+
+				// Two `Dependenc`ies with the same name point at the same `Package`.
+				by_lib_true_snakecased_name
+					.entry(lib_true_snakecased_name.clone())
+					.or_insert_with(HashSet::new)
+					.insert(dep.name_in_toml());
+			}
+		}
+
+		let ambiguous_normal_dev = ambiguous_names(&this.normal_dev_by_lib_true_snakecased_name);
+		let ambiguous_build = ambiguous_names(&this.build_by_lib_true_snakecased_name);
+
+		if !(ambiguous_normal_dev.is_empty() && ambiguous_build.is_empty()) {
+			let mut msg = format!(
+				"Currently `cargo-udeps` cannot distinguish multiple crates with the same `lib` name. This may cause false negative\n\
+				 `{}`\n",
+				from,
+			);
+			let (edge, joint) = if ambiguous_build.is_empty() {
+				(' ', '└')
+			} else {
+				('│', '├')
+			};
+			for (ambiguous, edge, joint, prefix) in &[
+				(ambiguous_normal_dev, edge, joint, "(dev-)"),
+				(ambiguous_build, ' ', '└', "build-"),
+			] {
+				if !ambiguous.is_empty() {
+					writeln!(msg, "{}─── {}dependencies", joint, prefix).unwrap();
+					let mut ambiguous = ambiguous.iter().peekable();
+					while let Some((dep, lib)) = ambiguous.next() {
+						let joint = if ambiguous.peek().is_some() {
+							'├'
+						} else {
+							'└'
+						};
+						writeln!(msg, "{}    {}─── {:?} → {:?}", edge, joint, dep, lib).unwrap();
+					}
+				}
+			}
+			shell.warn(msg.trim_end())?;
+		}
+
+		Ok(this)
+	}
 }
 
 fn main() -> Result<(), StrErr> {
@@ -309,77 +413,14 @@ fn main() -> Result<(), StrErr> {
 		.map(|p| (p.package_id(), p))
 		.collect::<HashMap<_, _>>();
 
-	let dependency_names = {
-		let mut dependency_names = HashMap::new();
-
-		for from in ws.members() {
-			let dependency_names = dependency_names
-				.entry(from.package_id())
-				.or_insert_with(DependencyNames::default);
-
-			if let Some(lib) = from.targets().iter().find(|t| t.is_lib()) {
-				let name = resolve.extern_crate_name(from.package_id(), from.package_id(), lib)?;
-				dependency_names.normal_dev_by_extern_crate_name.insert(name.clone(), from.name());
-				dependency_names.normal_dev_by_lib_true_snakecased_name.insert(name, from.name());
-			}
-
-			let from = from.package_id();
-			for (to_pkg, deps) in resolve.deps(from) {
-				let to_lib = packages
-					.get(&to_pkg)
-					.unwrap_or_else(|| panic!("could not find `{}`", &to_pkg))
-					.targets()
-					.iter()
-					.find(|t| t.is_lib())
-					.unwrap_or_else(|| panic!("`{}` does not have any `lib` target", to_pkg));
-
-				let extern_crate_name = resolve.extern_crate_name(from, to_pkg, to_lib)?;
-				let lib_true_snakecased_name = to_lib.name().replace('-', "_");
-
-				for dep in deps {
-					let (by_extern_crate_name, by_lib_true_snakecased_name, prefix) = if dep.is_build() {
-						(
-							&mut dependency_names.build_by_extern_crate_name,
-							&mut dependency_names.build_by_lib_true_snakecased_name,
-							"build-",
-						)
-					} else {
-						(
-							&mut dependency_names.normal_dev_by_extern_crate_name,
-							&mut dependency_names.normal_dev_by_lib_true_snakecased_name,
-							"(dev-)",
-						)
-					};
-
-					by_extern_crate_name.insert(extern_crate_name.clone(), dep.name_in_toml());
-
-					if let Some(name_in_toml) = by_lib_true_snakecased_name
-						.insert(lib_true_snakecased_name.clone(), dep.name_in_toml())
-					{
-						// If they are same, they should point at the same `Package`.
-						if dep.name_in_toml() != name_in_toml {
-							return Err(StrErr(format!(
-								"current implementation cannot handle multiple crates with the same `lib` name:\n\
-								`{id}`\n\
-								└── {prefix}dependencies\n    \
-									├── {name_in_toml1:?} → {lib_true_snakecased_name:?}\n    \
-									├── {name_in_toml2:?} → {lib_true_snakecased_name:?}\n    \
-									└── ..",
-								id = from,
-								prefix = prefix,
-								name_in_toml1 = dep.name_in_toml(),
-								name_in_toml2 = name_in_toml,
-								lib_true_snakecased_name = lib_true_snakecased_name,
-							)));
-						}
-					}
-
-				}
-			}
-		}
-
-		dependency_names
-	};
+	let dependency_names = ws
+		.members()
+		.map(|from| {
+             let val = DependencyNames::new(from, &packages, &resolve, &mut ws.config().shell())?;
+			 let key = from.package_id();
+			 Ok((key, val))
+		})
+		.collect::<CargoResult<HashMap<_, _>>>()?;
 
 	let data = Arc::new(Mutex::new(ExecData::new()));
 	let exec :Arc<dyn Executor + 'static> = Arc::new(Exec { data : data.clone() });
@@ -416,8 +457,10 @@ fn main() -> Result<(), StrErr> {
 				)
 			};
 			for ext in &analysis.prelude.external_crates {
-				if let Some(dependency_name) = by_lib_true_snakecased_name.get(&ext.id.name) {
-					used_dependencies.insert((cmd_info.pkg, *dependency_name));
+				if let Some(dependency_names) = by_lib_true_snakecased_name.get(&ext.id.name) {
+					for dependency_name in dependency_names {
+						used_dependencies.insert((cmd_info.pkg, *dependency_name));
+					}
 				}
 			}
 			for (name, _) in &cmd_info.externs {


### PR DESCRIPTION
Closes #22 this time.

With this change, it produces warnings of ambiguous `lib` names instead of errors.

```
warning: Currently `cargo-udeps` cannot distinguish multiple crates with the same `lib` name. This may cause false negative
`libra_wallet v0.1.0 (/home/ryo/src/libra/client/libra_wallet)`
└─── (dev-)dependencies
     ├─── "libra_crypto" → "crypto"
     └─── "rust-crypto" → "crypto"
```