### PR TITLE
Run `actions-rs/toolchain` on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,28 +43,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      # Suppress "Unable to find rustup, installing it now" warning.
-      - name: '`rustup-init`'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf -o /tmp/rustup-init https://sh.rustup.rs
-          bash /tmp/rustup-init -y --no-modify-path
-          ~/.cargo/bin/rustup install ${{ matrix.toolchain_nightly }}
-          echo "::add-path::$HOME/.cargo/bin"
-        if: matrix.toolchain == 'stable-x86_64-apple-darwin'
-
       - name: rust-toolchain ( ${{ matrix.toolchain }} )
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
           default: true
-        if: matrix.toolchain != 'stable-x86_64-apple-darwin'
 
       - name: rust-toolchain ( ${{ matrix.toolchain_nightly }} )
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain_nightly }}
           default: false
-        if: matrix.toolchain != 'stable-x86_64-apple-darwin'
 
       - name: '`cargo build`'
         uses: actions-rs/cargo@v1
@@ -105,19 +94,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: '`rustup-init`'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf -o /tmp/rustup-init https://sh.rustup.rs
-          bash /tmp/rustup-init -y --no-modify-path
-          echo "::add-path::$HOME/.cargo/bin"
-        if: matrix.target == 'x86_64-apple-darwin'
-
       - name: rust-toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable-${{ matrix.target }}
           default: true
-        if: matrix.target != 'x86_64-apple-darwin'
 
       - name: '`cargo build --release`'
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
[We no longer need to run `rustup-init` directly.](https://github.com/actions-rs/toolchain/pull/13)