### PR TITLE
Recognize `--profile test` as `cargo check` does

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,15 @@ impl OptUdeps {
 			&[],
 		)?;
 		let ws = clap_matches.workspace(config)?;
-		let mode = CompileMode::Check { test : false };
+		let test = match self.profile.as_ref().map(Deref::deref) {
+			None => false,
+			Some("test") => true,
+			Some(profile) => return Err(failure::format_err!(
+				"unknown profile: `{}`, only `test` is currently supported",
+				profile,
+			)),
+		};
+		let mode = CompileMode::Check { test };
 		let compile_opts = clap_matches.compile_options(config, mode, Some(&ws))?;
 
 		let (packages, resolve) = cargo::ops::resolve_ws_precisely(


### PR DESCRIPTION
With `--profile test`, `cargo check` can check `#[cfg(test)]` items without involving `integration-test`s. This PR makes `cargo-udeps` recognize `--profile test` by setting `test` of `CompileMode::Check` in the same way. Previously `cargo-udeps`' `--profile` is just ignored.

<https://github.com/rust-lang/cargo/blob/0.39.0/src/bin/cargo/commands/check.rs#L59-L71>