### PR TITLE
Update github actions checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: rust-toolchain ( ${{ matrix.toolchain }} )
         uses: actions-rs/toolchain@v1
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: rust-toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
CI broke due to an upstream bug,
solution is updating the library:

See https://github.com/actions/checkout/issues/23