### PR TITLE
Fix a grammatical nit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,7 +520,7 @@ impl OptUdeps {
 
 			note += "Note: They might be false-positive.\n";
 			note += "      For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.\n";
-			note += "      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.\n";
+			note += "      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.\n";
 
 			outcome.note = Some(note);
 		}

--- a/tests/ignore.rs
+++ b/tests/ignore.rs
@@ -41,7 +41,7 @@ matches = "0.1.8"
      └─── "matches"
 Note: They might be false-positive.
       For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
-      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
 "#,
 		stdout_masked,
 	);

--- a/tests/non-lib-build-dep.rs
+++ b/tests/non-lib-build-dep.rs
@@ -37,7 +37,7 @@ Note: Some dependencies are non-library packages.
       `cargo-udeps` regards them as unused.
 Note: They might be false-positive.
       For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
-      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
 "#,
 		stdout_masked,
 	);
@@ -64,7 +64,7 @@ Note: Some dependencies are non-library packages.
       `cargo-udeps` regards them as unused.
 Note: They might be false-positive.
       For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
-      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
 "#,
 		stdout_masked,
 	);

--- a/tests/normal-dev-build.rs
+++ b/tests/normal-dev-build.rs
@@ -47,7 +47,7 @@ Note: These dependencies might be used by other targets.
       To find dependencies that are not used by any target, enable `--all-targets`.
 Note: They might be false-positive.
       For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
-      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
 "#,
 		stdout_masked,
 	);
@@ -77,7 +77,7 @@ fn with_all_targets() -> CargoResult<()> {
      └─── "matches"
 Note: They might be false-positive.
       For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
-      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
 "#,
 		stdout_masked,
 	);

--- a/tests/unused-byteorder.rs
+++ b/tests/unused-byteorder.rs
@@ -33,7 +33,7 @@ Note: These dependencies might be used by other targets.
       To find dependencies that are not used by any target, enable `--all-targets`.
 Note: They might be false-positive.
       For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
-      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
 "#,
 		stdout_masked,
 	);
@@ -58,7 +58,7 @@ fn with_all_targets() -> CargoResult<()> {
      └─── "byteorder"
 Note: They might be false-positive.
       For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
-      To ignore some of dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
 "#,
 		stdout_masked,
 	);


### PR DESCRIPTION
Noticed this when trying out cargo-udeps, figured I'd send in a patch.