### PR TITLE
Fix the usage of `cargo::Config::new` in the tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,18 +40,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,12 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,17 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -191,7 +162,6 @@ dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
  "cargo",
- "dirs",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -246,12 +216,6 @@ checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -362,26 +326,6 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "dirs"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
 
 [[package]]
 name = "env_logger"
@@ -926,17 +870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "rust-argon2",
-]
-
-[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,18 +894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ structopt = "0.3"
 anyhow = "1.0"
 
 [dev-dependencies]
-dirs = "3.0"
 pretty_assertions = "0.6"
 tempfile = "3.1"
 


### PR DESCRIPTION
Replaces `dirs::home_dir()` with `cargo::util::config::homedir()` in the tests, as "homedir" in `cargo` does not mean "home directory" but `$CARGO_HOME` (= `~/.cargo`).

```console
[src/main.rs:2] dirs_next::home_dir().unwrap() = "/home/ryo"
[src/main.rs:3] home::cargo_home().unwrap() = "/home/ryo/.cargo"
[src/main.rs:4] cargo::Config::default().unwrap().home().as_path_unlocked() = "/home/ryo/.cargo"
```

Also this PR removes `dir` crate, which is unmaintained and [is in `insecure` status on deps.rs](https://deps.rs/repo/github/est31/cargo-udeps).

```console
❯ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 135 security advisories (from /home/ryo/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (142 crate dependencies)
error: Vulnerable crates found!

ID:       RUSTSEC-2020-0041
Crate:    sized-chunks
Version:  0.6.2
Date:     2020-09-06
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0041
Title:    Multiple soundness issues in Chunk and InlineArray
Solution:  No safe upgrade is available!
Dependency tree:
sized-chunks 0.6.2
└── im-rc 15.0.0
    └── cargo 0.48.0
        └── cargo-udeps 0.1.15

warning: 1 warning found

Crate:  dirs
Title:  dirs is unmaintained, use dirs-next instead
Date:   2020-10-16
URL:    https://rustsec.org/advisories/RUSTSEC-2020-0053
Dependency tree:
dirs 3.0.1
└── cargo-udeps 0.1.15

error: 1 vulnerability found!
warning: 1 warning found!
```
