### PR TITLE
update cargo version to 0.50.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ba419c30742fe3aa35eb9badcaea2901ef08c7b61e66f2505be2f48d4afe7c"
+checksum = "9e85a774d067a36bd0874fdb068e2e70aa6b1a7a22a5de9dc100219c7421e2eb"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 ansi_term = "0.12"
-cargo = "0.50"
+cargo = "0.50.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"


### PR DESCRIPTION
The build is [currently broken](https://github.com/est31/cargo-udeps/runs/1814047003).

This PR updates the cargo version to fix the following error:
```
error[E0283]: type annotations needed
Error:    --> C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\cargo-0.50.0\src/cargo\util\config\de.rs:530:63
    |
530 |                 seed.deserialize(Tuple2Deserializer(1i32, env.as_ref()))
    |                                                           ----^^^^^^--
    |                                                           |   |
    |                                                           |   cannot infer type for type parameter `T` declared on the trait `AsRef`
    |                                                           this method call resolves to `&T`
    |
    = note: cannot satisfy `std::string::String: AsRef<_>`
```