### PR TITLE
Add optional `vendored-openssl` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "miow",
  "num_cpus",
  "opener",
+ "openssl",
  "percent-encoding",
  "rustc-workspace-hack",
  "rustfix",
@@ -721,6 +722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.14.0+1.1.1j"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +739,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+vendored-openssl = ["cargo/vendored-openssl"]
+
 [dependencies]
 ansi_term = "0.12"
 cargo = "0.51"


### PR DESCRIPTION
`openssl` crate won't work in some environments without vendored openssl (see #89).
To deal with this problem, default-disabled `vendored-openssl` feature of `cargo` crate can be used.

This commit adds default-disabled `vendored-openssl` feature to `cargo-udeps` itself, to provide the way to avoid this issue on user side without modifying the source.

Solves #89.