### PR TITLE
setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Hi, 

following up on #116, I propose to configure dependabot, a GitHub service that watches the dependencies and opens pull requests, when it finds newer versions to be available.

Here is an example of a PR opened by dependabot: https://github.com/jcornaz/heron/pull/169

And, the github documentation about dependabot: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates


This is merely a suggestion. If you are not interested, you can simply close this PR ;-)