### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-udeps"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "ansi_term",
  "anyhow",


### PR DESCRIPTION
`Cargo.toml` was updated in [28a2d3d](https://github.com/est31/cargo-udeps/commit/28a2d3dbe2907a366ffda49596654542a9941568) but `Cargo.lock` wasn't updated accordingly.
