### PR TITLE
Build with `--locked` flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --verbose
+          args: --verbose --locked
 
       # `locked`, `avoid-dev-deps`
       - name: '`cargo install --debug --locked`'


### PR DESCRIPTION
So that issues like #120 can be spotted early in development.
