### PR TITLE
Test with `--locked` flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast --verbose
+          args: --no-fail-fast --verbose --locked
         env:
           CARGO_UDEPS_TEST_TOOLCHAIN: ${{ matrix.toolchain_nightly }}
 


### PR DESCRIPTION
Build checks for #121 was expected to fail since `Cargo.lock` wasn't updated accordingly. But they didn't, it's because `cargo test` is called first in the workflow thus `Cargo.lock` is updated afterwards. Then calling `cargo build --locked` will work anyways.

This PR updates the workflow file to run tests via `--locked` flag so that issues like #120 can be spotted.

P.S. I didn't revert #121, I guess it does no harm to have it there but let me know :bear:
