### PR TITLE
Ensure using GNU tar for GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,12 @@ jobs:
             zipinfo "$ASSET"
           else
             ASSET="./$ASSET_STEM.tar.gz"
-            tar -czvf "$ASSET" "./$ASSET_STEM"
+            if ${{ runner.os == 'macOS' }}; then
+              tar=gtar
+            else
+              tar=tar
+            fi
+            "$tar" -czvf "$ASSET" "./$ASSET_STEM"
           fi
           echo "::set-output name=asset::$ASSET"
         shell: bash


### PR DESCRIPTION
Currently, [cargo-binstall](https://github.com/ryankurte/cargo-binstall) cannot be used for cargo-udeps on macOS due to alexcrichton/tar-rs#295.