### PR TITLE
Unused transitive dependecies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,13 @@ impl OptUdeps {
 				| {
 					match &backend_data {
 						BackendData::SaveAnalysis(analysis) => for ext in &analysis.prelude.external_crates {
+                            let is_used = analysis
+                                .refs
+                                .iter()
+                                .any(|r#ref| r#ref.ref_id.krate == ext.num);
+                            if !is_used {
+                                continue;
+                            }
 							if let Some(dependency_names) = dnv.by_lib_true_snakecased_name.get(&*ext.id.name) {
 								for dependency_name in dependency_names {
 									used_dependencies.insert((cmd_info.pkg, *dependency_name));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,11 +250,7 @@ impl OptUdeps {
 		}
 
 		config.configure(
-			match self.verbose {
-				0 => 0,
-				1 => 1,
-				_ => 2,
-			},
+			self.verbose.max(0).min(2) as u32,
 			self.quiet,
 			self.color.as_deref(),
 			self.frozen,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,7 +618,7 @@ impl Executor for Exec {
 		if is_workspace_member {
 			// This reduces the save analysis files that are being created a little
 			std::env::set_var("RUST_SAVE_ANALYSIS_CONFIG",
-				r#"{ "reachable_only": true, "full_docs": false, "pub_only": false, "distro_crate": false, "signatures": false, "borrow_data": false }"#);
+				r#"{ "reachable_only": false, "full_docs": false, "pub_only": false, "distro_crate": false, "signatures": false, "borrow_data": false }"#);
 			if let Backend::SaveAnalysis = self.backend {
 				cmd.arg("-Z").arg("save-analysis");
 			}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,9 +411,10 @@ impl OptUdeps {
 							// First, we continue if there is no - in the filename.
 							// it's likely a source file or some other artifact we aren't
 							// interested in. This is obviously only a stupid heuristic.
-							if !fs.contains('-') {
-								continue;
-							}
+							let lib_name = match fs.split_once('-') {
+								None => continue,
+								Some((lib_name, _)) => lib_name
+							};
 
 							// The metadata hash is not available through cargo's api
 							// outside of the Executor trait impl. We do our best to obtain
@@ -430,7 +431,6 @@ impl OptUdeps {
 									used_dependencies.insert((cmd_info.pkg, *dependency_name));
 								}
 							} else {
-								let lib_name = fs.split('-').next().unwrap();
 								// TODO this is a hack as we unconditionally strip the prefix.
 								// It won't work for proc macro crates that start with "lib".
 								// See maybe_lib in the code above.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ struct OptUdeps {
 	keep_going :bool,
 	#[structopt(
 		long,
-		help("Ignore unused dependencies that gets used transitively by main dependencies. \
+		help("Ignore unused dependencies that get used transitively by main dependencies. \
 			  Works only with 'save-analysis' backend"),
 	)]
 	hide_unused_transitive :bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,11 +434,7 @@ impl OptUdeps {
 								// TODO this is a hack as we unconditionally strip the prefix.
 								// It won't work for proc macro crates that start with "lib".
 								// See maybe_lib in the code above.
-								let lib_name = if lib_name.starts_with("lib") {
-										&lib_name["lib".len()..]
-								} else {
-										&lib_name[..]
-								};
+								let lib_name = lib_name.strip_prefix("lib").unwrap_or(lib_name);
 								if let Some(dependency_names) = dnv.by_lib_true_snakecased_name.get(lib_name) {
 									for dependency_name in dependency_names {
 										used_dependencies.insert((cmd_info.pkg, *dependency_name));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ impl OptUdeps {
 							analysis
 								.refs
 								.iter()
-								.map(|r#ref| r#ref.ref_id.krate)
+								.map(|ref_| ref_.ref_id.krate)
 								.collect(),
 						),
 					};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,8 @@ struct OptUdeps {
 	keep_going :bool,
 	#[structopt(
 		long,
-		help("Ignore unused dependencies that gets used transitively by main dependencies"),
+		help("Ignore unused dependencies that gets used transitively by main dependencies. \
+			  Works only with 'save-analysis' backend"),
 	)]
 	hide_unused_transitive :bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,9 +225,8 @@ struct OptUdeps {
 	backend :Backend,
 	#[structopt(
 		long,
-		help("Backend to use for determining unused deps"))
+		help("Needed because the keep-going flag is asked about by cargo code"))
 	]
-	// This is needed because the keep-going flag is asked about by cargo code.
 	keep_going :bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,7 +729,7 @@ impl DepInfo {
 				v.file_name() == Some(&std::ffi::OsString::from(&self.f_name))
 			})
 			.map(|v| v.1.clone())
-			.unwrap_or(vec![])
+			.unwrap_or_default()
 	}
 }
 

--- a/tests/unused-transitive.rs
+++ b/tests/unused-transitive.rs
@@ -1,0 +1,60 @@
+mod runner;
+
+use cargo::CargoResult;
+use pretty_assertions::assert_eq;
+
+use crate::runner::Runner;
+
+static CARGO_TOML :&str = r#"[workspace]
+[package]
+name = "unused_transitive"
+version = "0.0.1"
+[dependencies]
+chrono = "0.4"
+time = "0.1"
+"#;
+
+static LIB_RS :&str = r#"
+fn main() {
+    println!("{:?}", chrono::Local::now());
+}
+"#;
+
+#[test]
+fn unused_transitive() -> CargoResult<()> {
+	let (code, stdout_masked) =
+		Runner::new("cargo_udeps_test_unused_transitive")?
+			.cargo_toml(CARGO_TOML)?
+			.dir("./src")?
+			.file("./src/lib.rs", LIB_RS)?
+			.arg("--all-targets")
+			.run()?;
+	assert_eq!(1, code);
+	assert_eq!(
+		r#"unused dependencies:
+`unused_transitive v0.0.1 (██████████)`
+└─── dependencies
+     └─── "time"
+Note: They might be false-positive.
+      For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+"#,
+		stdout_masked,
+	);
+	Ok(())
+}
+
+#[test]
+fn hide_unused_transitive() -> CargoResult<()> {
+	let (code, stdout_masked) =
+		Runner::new("cargo_udeps_test_hide_unused_transitive")?
+			.cargo_toml(CARGO_TOML)?
+			.dir("./src")?
+			.file("./src/lib.rs", LIB_RS)?
+			.arg("--all-targets")
+			.arg("--hide-unused-transitive")
+			.run()?;
+	assert_eq!(0, code);
+	assert_eq!("All deps seem to have been used.\n", stdout_masked);
+	Ok(())
+}


### PR DESCRIPTION
This pull requests fixes #84 issue.

It does so by setting `"reachable_only": false` flag for `RUST_SAVE_ANALYSIS_CONFIG` env variable. This flag enables populations of `"refs"` field in save-analysis files. These `"refs"` contain parsed info about code structure, like variables, modules, types, etc, that are actually used.

For example, refs can contain this structure:
```json
    {
      "kind": "Type",
      "span": {
        "file_name": "src/main.rs",
        "byte_start": 208,
        "byte_end": 213,
        "line_start": 10,
        "line_end": 10,
        "column_start": 30,
        "column_end": 35
      },
      "ref_id": {
        "krate": 22,
        "index": 2246
      }
    },
```
`krate: 22` means usage of type from `chrono` crate. We can know it because same id is used in `external_crates` section of save-analysis file (have same `num=22` id):
```json
      {
        "file_name": "/home/artslob/projects/test-staff/src/main.rs",
        "num": 22,
        "id": {
          "name": "chrono",
          "disambiguator": [
            5191221466124674000,
            0
          ]
        }
      },
```
This feature works only with save-analysis backend. 

Also added cli flag to disable this feature: `hide_unused_transitive`.