### PR TITLE
Disable showing transitive by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,10 +231,10 @@ struct OptUdeps {
 	keep_going :bool,
 	#[structopt(
 		long,
-		help("Ignore unused dependencies that get used transitively by main dependencies. \
+		help("Show unused dependencies that get used transitively by main dependencies. \
 			  Works only with 'save-analysis' backend"),
 	)]
-	hide_unused_transitive :bool,
+	show_unused_transitive :bool,
 }
 
 impl OptUdeps {
@@ -349,15 +349,15 @@ impl OptUdeps {
 			let backend_data = match self.backend {
 				Backend::SaveAnalysis => {
 					let analysis = cmd_info.get_save_analysis(&mut config.shell())?;
-					let ref_krate_ids = match self.hide_unused_transitive {
-						true => None,
-						false => Some(
+					let ref_krate_ids = match self.show_unused_transitive {
+						true => Some(
 							analysis
 								.refs
 								.iter()
 								.map(|ref_| ref_.ref_id.krate)
 								.collect(),
 						),
+						false => None,
 					};
 					BackendData::SaveAnalysis {
 						analysis,

--- a/tests/check-macro-with-transitive-flag.rs
+++ b/tests/check-macro-with-transitive-flag.rs
@@ -1,0 +1,62 @@
+mod runner;
+
+use cargo::CargoResult;
+use pretty_assertions::assert_eq;
+
+use crate::runner::Runner;
+
+static CARGO_TOML :&str = r#"[workspace]
+[package]
+name = "strum_macro"
+version = "0.0.1"
+[dependencies]
+strum = { version = "0.24", features = ["derive"] }
+"#;
+
+static LIB_RS :&str = r#"
+#[derive(strum::AsRefStr)]
+pub enum Color {
+    Red,
+}
+"#;
+
+#[test]
+fn macro_call() -> CargoResult<()> {
+	let (code, stdout_masked) =
+		Runner::new("cargo_udeps_test_macro_call")?
+			.cargo_toml(CARGO_TOML)?
+			.dir("./src")?
+			.file("./src/lib.rs", LIB_RS)?
+			.arg("--all-targets")
+			.run()?;
+	assert_eq!(0, code);
+	assert_eq!("All deps seem to have been used.\n", stdout_masked);
+	Ok(())
+}
+
+/// For now we can't check if macro is really used in crate, because macro usages do not populate
+/// "refs" section of save-analysis file.
+#[test]
+fn macro_call_with_unused_transitive_flag() -> CargoResult<()> {
+	let (code, stdout_masked) =
+		Runner::new("cargo_udeps_test_macro_call_with_unused_transitive_flag")?
+			.cargo_toml(CARGO_TOML)?
+			.dir("./src")?
+			.file("./src/lib.rs", LIB_RS)?
+			.arg("--all-targets")
+			.arg("--show-unused-transitive")
+			.run()?;
+	assert_eq!(1, code);
+	assert_eq!(
+		r#"unused dependencies:
+`strum_macro v0.0.1 (██████████)`
+└─── dependencies
+     └─── "strum"
+Note: They might be false-positive.
+      For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
+      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
+"#,
+		stdout_masked,
+	);
+	Ok(())
+}

--- a/tests/unused-transitive.rs
+++ b/tests/unused-transitive.rs
@@ -21,13 +21,14 @@ fn main() {
 "#;
 
 #[test]
-fn unused_transitive() -> CargoResult<()> {
+fn show_unused_transitive() -> CargoResult<()> {
 	let (code, stdout_masked) =
-		Runner::new("cargo_udeps_test_unused_transitive")?
+		Runner::new("cargo_udeps_test_show_unused_transitive")?
 			.cargo_toml(CARGO_TOML)?
 			.dir("./src")?
 			.file("./src/lib.rs", LIB_RS)?
 			.arg("--all-targets")
+			.arg("--show-unused-transitive")
 			.run()?;
 	assert_eq!(1, code);
 	assert_eq!(
@@ -45,14 +46,13 @@ Note: They might be false-positive.
 }
 
 #[test]
-fn hide_unused_transitive() -> CargoResult<()> {
+fn unused_transitive() -> CargoResult<()> {
 	let (code, stdout_masked) =
-		Runner::new("cargo_udeps_test_hide_unused_transitive")?
+		Runner::new("cargo_udeps_test_unused_transitive")?
 			.cargo_toml(CARGO_TOML)?
 			.dir("./src")?
 			.file("./src/lib.rs", LIB_RS)?
 			.arg("--all-targets")
-			.arg("--hide-unused-transitive")
 			.run()?;
 	assert_eq!(0, code);
 	assert_eq!("All deps seem to have been used.\n", stdout_masked);


### PR DESCRIPTION
By default disables flag introduced in #129 PR. The problem is that macro calls are not showed in "refs" section of save-analysis file (or any other section of it, as I can tell). Test with macro call shows this behavior. 