### PR TITLE
Fix: `cargo-udeps` 1.0.36 crashes when given a `manifest-path`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ struct OptUdeps {
 	)]
 	target_dir: Option<PathBuf>,
 	#[arg(long, value_name("PATH"), id = "manifest-path", help("[cargo] Path to Cargo.toml"))]
-	manifest_path: Option<PathBuf>,
+	manifest_path: Option<String>,
 	#[arg(
 		long,
 		value_name("FMT"),


### PR DESCRIPTION
See #154 for the crash report & how to reproduce.

Note: I didn't run extensive tests to verify this change would not break other things.