### PR TITLE
Fix output of `asset` step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
             ASSET="./$ASSET_STEM.tar.gz"
             tar -czvf "$ASSET" "./$ASSET_STEM"
           fi
-          echo "name=asset::$ASSET" >> $GITHUB_OUTPUT
+          echo "asset::$ASSET" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: GH Release


### PR DESCRIPTION
The output syntax is wrong so there isn't any asset in 0.1.36 release

logs from CI:
https://github.com/est31/cargo-udeps/actions/runs/4835953208/jobs/8618834421#step:6:13
```
 🤔  not include valid file.
```
