### PR TITLE
Build release artifacts with ` --features vendored-openssl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
           toolchain: stable-${{ matrix.target }}
           default: true
 
-      - name: '`cargo build --release`'
-        run: cargo build --release
+      - name: '`cargo build --release --features vendored-openssl`'
+        run: cargo build --release --features vendored-openssl
 
       - name: Create an asset
         id: asset


### PR DESCRIPTION
`cargo-udeps` v0.1.38 breaks taiki-e/install-action since ubuntu-20.04 does not have openssl 3 installed https://github.com/taiki-e/install-action/pull/114