### PR TITLE
Speedup CI: Use `sccache` for caching

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,26 @@
+name: Cleanup caches for closed PRs
+
+on:
+  schedule:
+    - cron: "0 17 * * *"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          export REPO="${{ github.repository }}"
+
+          gh pr list --state closed -L 20 --json number --jq '.[]|.number' | (
+              while IFS='$\n' read -r closed_pr; do
+                  BRANCH="refs/pull/${closed_pr}/merge" ./cleanup-cache.sh
+              done
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,8 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
           restore-keys: |
-            ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-index-
 
       - name: rust-toolchain ( ${{ matrix.toolchain_nightly }} )
@@ -127,9 +126,8 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
           restore-keys: |
-            ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-index-
 
       - name: rust-toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 env:
   RUSTFLAGS: -D warnings
   UDEPS_VERBOSE_TEST: 1
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build:
@@ -46,6 +49,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: rust-toolchain ( ${{ matrix.toolchain_nightly }} )
         uses: dtolnay/rust-toolchain@master
@@ -98,6 +104,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: rust-toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,18 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
+      - name: Configure index cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-index-
+
       - name: rust-toolchain ( ${{ matrix.toolchain_nightly }} )
         uses: dtolnay/rust-toolchain@master
         with:
@@ -107,6 +119,18 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
+
+      - name: Configure index cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-index-
 
       - name: rust-toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-index-
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: rust-toolchain ( ${{ matrix.toolchain_nightly }} )
         uses: dtolnay/rust-toolchain@master
         with:
@@ -74,8 +78,8 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - name: '`cargo test`'
-        run: cargo test --no-fail-fast --verbose --locked
+      - name: '`cargo nextest run`'
+        run: cargo nextest run --no-fail-fast --verbose --locked
         env:
           CARGO_UDEPS_TEST_TOOLCHAIN: ${{ matrix.toolchain_nightly }}
 

--- a/cleanup-cache.sh
+++ b/cleanup-cache.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -uxo pipefail
+
+REPO="${REPO?}"
+BRANCH="${BRANCH?}"
+
+while true; do
+    echo "Fetching list of cache key for $BRANCH"
+    cacheKeysForPR="$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 )"
+
+    if [ -z "$cacheKeysForPR" ]; then
+        break
+    fi
+
+    ## Setting this to not fail the workflow while deleting cache keys. 
+    set +e
+    echo "Deleting caches..."
+    for cacheKey in $cacheKeysForPR
+    do
+        echo Removing "$cacheKey"
+        gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+    done
+done
+echo "Done cleaning up $BRANCH"


### PR DESCRIPTION
Also add `cache-cleanup.yml` to cleanup caches for PRs that cannot be reused.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>