### PR TITLE
Build release artifacts in ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
 
     name: GitHub Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
+            # Use ubuntu-20.04 so that the pre-built artifacts can run on older
+            # image, where they are still using openssl 1
             os: ubuntu-20.04
 
     name: GitHub Release (${{ matrix.target }})


### PR DESCRIPTION
cargo-udeps v0.1.38 breaks `taiki-e/install-action` since ubunut-latest uses incompatible openssl taiki-e/install-action#114

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>