### PR TITLE
Build release artifacts for more targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
     name: GitHub Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [build]
-    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout
@@ -131,6 +130,7 @@ jobs:
         shell: bash
 
       - name: GH Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ steps.asset.outputs.asset }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
             # Use ubuntu-20.04 so that the pre-built artifacts can run on older
             # image, where they are still using openssl 1
             os: ubuntu-20.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-20.04
+            c: true
 
     name: GitHub Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -105,7 +108,14 @@ jobs:
           default: true
 
       - name: '`cargo build --release`'
+        if: "!matrix.c"
         run: cargo build --release --target ${{ matrix.target }}
+
+      - name: '`cargo zigbuild --release`'
+        if: "matrix.c"
+        run: |
+          pip3 install cargo-zigbuild
+          cargo zigbuild --release --target ${{ matrix.target }}
 
       - name: Create an asset
         id: asset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,8 @@ jobs:
       - name: rust-toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable-${{ matrix.target }}
+          toolchain: stable
+          targets: ${{ matrix.target }}
           default: true
 
       - name: '`cargo build --release`'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-20.04
             c: true
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-20.04
+            c: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-20.04
+            c: true
 
     name: GitHub Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         if: "matrix.c"
         run: |
           pip3 install cargo-zigbuild
-          cargo zigbuild --release --target ${{ matrix.target }}
+          cargo zigbuild --release --target ${{ matrix.target }} --features vendored-openssl,vendored-libgit2
 
       - name: Create an asset
         id: asset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,6 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-20.04
             c: true
-          - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-20.04
-            c: true
-          - target: armv7-unknown-linux-musleabihf
-            os: ubuntu-20.04
-            c: true
 
     name: GitHub Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,12 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-20.04
             c: true
+          - target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-20.04
+            c: true
+          - target: armv7-unknown-linux-musleabihf
+            os: ubuntu-20.04
+            c: true
 
     name: GitHub Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         include:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+            args: "--features vendored-openssl,vendored-libgit2"
           - target: x86_64-unknown-linux-gnu
             # Use ubuntu-20.04 so that the pre-built artifacts can run on older
             # image, where they are still using openssl 1
@@ -118,7 +119,7 @@ jobs:
 
       - name: '`cargo build --release`'
         if: "!matrix.c"
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.args }}
 
       - name: '`cargo zigbuild --release`'
         if: "matrix.c"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
   release:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - target: x86_64-pc-windows-msvc
@@ -105,6 +105,7 @@ jobs:
     name: GitHub Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout
@@ -150,7 +151,6 @@ jobs:
         shell: bash
 
       - name: GH Release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ steps.asset.outputs.asset }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
   release:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target:
-          - x86_64-pc-windows-msvc
-          - x86_64-apple-darwin
-          - x86_64-unknown-linux-gnu
         include:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
           - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
             # Use ubuntu-20.04 so that the pre-built artifacts can run on older
@@ -108,7 +106,7 @@ jobs:
           default: true
 
       - name: '`cargo build --release`'
-        run: cargo build --release
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Create an asset
         id: asset
@@ -116,7 +114,7 @@ jobs:
           if ${{ contains(matrix.target, 'pc-windows') }}; then
             EXE=.exe
           fi
-          EXECUTABLE="./target/release/${GITHUB_REPOSITORY#*/}$EXE"
+          EXECUTABLE="./target/${{ matrix.target }}/release/${GITHUB_REPOSITORY#*/}$EXE"
           ASSET_STEM="${GITHUB_REPOSITORY#*/}-${GITHUB_REF#refs/tags/}-${{ matrix.target }}"
           git archive -o "./$ASSET_STEM.tar" --prefix "$ASSET_STEM/" HEAD
           tar -xf "./$ASSET_STEM.tar"


### PR DESCRIPTION
Build for:
 - aarch64-apple-darwin
 - x86_64-unknown-linux-musl
 - aarch64-unknown-linux-gnu
 - aarch64-unknown-linux-musl
 - aarch64-pc-windows-msvc

This PR also enables features vendored-{openssl, libgit2} for cross compilation, including all linux targets and `aarch64-apple-darwin`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>