### PR TITLE
Support arbitrary profile names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,12 +261,8 @@ impl OptUdeps {
 		assert!(config.nightly_features_allowed);
 		let ws = clap_matches.workspace(config)?;
 		let test = match self.profile.as_deref() {
-			None => false,
 			Some("test") => true,
-			Some(profile) => return Err(anyhow::anyhow!(
-				"unknown profile: `{}`, only `test` is currently supported",
-				profile,
-			)),
+			_ => false,
 		};
 		let mode = UserIntent::Check { test };
 		let pc = ProfileChecking::LegacyTestOnly;


### PR DESCRIPTION
Add support for arbitrary profile names, just like other [cargo commands](https://github.com/rust-lang/cargo/blob/6ea2e7161c1cf1c2ed9f96455d33d8d14018753b/src/bin/cargo/commands/check.rs#L48-L53).

Fix: https://github.com/est31/cargo-udeps/issues/333